### PR TITLE
Use `useBluelibInBody` hook to prevent white stripes on overflows

### DIFF
--- a/frontend/erre2-navigator/package-lock.json
+++ b/frontend/erre2-navigator/package-lock.json
@@ -11,7 +11,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.15",
-        "@steffo/bluelib-react": "^4.2.0",
+        "@steffo/bluelib-react": "^4.5.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.2.1",
@@ -2769,9 +2769,9 @@
       }
     },
     "node_modules/@steffo/bluelib-react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@steffo/bluelib-react/-/bluelib-react-4.2.0.tgz",
-      "integrity": "sha512-meWWsjiD4cjt7A2nbQHbtY6iFdVJyjlbzUUH5zcPCwVtL6H8gTZ5VTabw+38j5ydDToTd4u9/LNdl8DMq2EcQg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@steffo/bluelib-react/-/bluelib-react-4.5.1.tgz",
+      "integrity": "sha512-KoQloFMKlkOCuTIiMaVyKOR6pNdr8OKXuybzzmtkafJD7dR/iiDYcoTuy+Mj6VPXCaCUTKahireciTEpObFL/g==",
       "dependencies": {
         "@babel/runtime": "^7.15.3",
         "classnames": "^2.3.1",
@@ -22715,9 +22715,9 @@
       }
     },
     "@steffo/bluelib-react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@steffo/bluelib-react/-/bluelib-react-4.2.0.tgz",
-      "integrity": "sha512-meWWsjiD4cjt7A2nbQHbtY6iFdVJyjlbzUUH5zcPCwVtL6H8gTZ5VTabw+38j5ydDToTd4u9/LNdl8DMq2EcQg==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@steffo/bluelib-react/-/bluelib-react-4.5.1.tgz",
+      "integrity": "sha512-KoQloFMKlkOCuTIiMaVyKOR6pNdr8OKXuybzzmtkafJD7dR/iiDYcoTuy+Mj6VPXCaCUTKahireciTEpObFL/g==",
       "requires": {
         "@babel/runtime": "^7.15.3",
         "classnames": "^2.3.1",

--- a/frontend/erre2-navigator/package.json
+++ b/frontend/erre2-navigator/package.json
@@ -6,7 +6,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
-    "@steffo/bluelib-react": "^4.2.0",
+    "@steffo/bluelib-react": "^4.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.1",

--- a/frontend/erre2-navigator/src/App.js
+++ b/frontend/erre2-navigator/src/App.js
@@ -3,7 +3,7 @@ import './App.css';
 import {AppContext} from "./libs/Context"
 import React, {useEffect, useState} from "react";
 import {useHistory} from "react-router-dom";
-import {Bluelib, Footer, LayoutThreeCol} from "@steffo/bluelib-react";
+import {Bluelib, Footer, LayoutThreeCol, useBluelibInBody} from "@steffo/bluelib-react";
 
 function App() {
     const [instanceIp, setInstanceIp] = useState("");
@@ -21,28 +21,27 @@ function App() {
         }
     }
 
-    return (
+    useBluelibInBody("amber");
 
-        <Bluelib theme={"amber"}>
-            <LayoutThreeCol>
-                <LayoutThreeCol.Center>
-            <div className="App">
-                <AppContext.Provider value={{instanceIp, setInstanceIp, connected, setConnected, token, setToken}}>
-                    <Routes/>
+    return <>
+        <LayoutThreeCol>
+            <LayoutThreeCol.Center>
+        <div className="App">
+            <AppContext.Provider value={{instanceIp, setInstanceIp, connected, setConnected, token, setToken}}>
+                <Routes/>
 
 
-                </AppContext.Provider>
+            </AppContext.Provider>
 
-            </div>
-                </LayoutThreeCol.Center>
-            </LayoutThreeCol>
-            <div className="Fermitech-Footer">
-                <Footer>Erre2, Erre2.0, Erre2-Navigator sono software di Fermitech Softworks.
-                <p>Erre2-Navigator usa <a href={"https://github.com/Steffo99/bluelib-react"}>bluelib-react</a> di Steffo.</p>
-                <p>Fermitech-Softworks non si assume alcuna responsabilità per i contenuti
-                caricati su istanze private.</p></Footer>
-            </div>
-        </Bluelib>
-    );
+        </div>
+            </LayoutThreeCol.Center>
+        </LayoutThreeCol>
+        <div className="Fermitech-Footer">
+            <Footer>Erre2, Erre2.0, Erre2-Navigator sono software di Fermitech Softworks.
+            <p>Erre2-Navigator usa <a href={"https://github.com/Steffo99/bluelib-react"}>bluelib-react</a> di Steffo.</p>
+            <p>Fermitech-Softworks non si assume alcuna responsabilità per i contenuti
+            caricati su istanze private.</p></Footer>
+        </div>
+    </>
 }
 export default App;


### PR DESCRIPTION
Additionally, this commit upgrades `@steffo/bluelib-react` to versions `^4.5.1`.